### PR TITLE
Remove nav-lang and close option on alert blox

### DIFF
--- a/EPFL-translate.php
+++ b/EPFL-translate.php
@@ -105,6 +105,11 @@ function display_banner () {
       const isTranslated = window.location.hostname.includes("translate.goog");
       if (!isTranslated) return;
 
+      const navLang = document.querySelector('.nav-lang');
+      if (navLang) {
+          navLang.style.display = 'none';
+      }
+
       const marker = document.getElementById("wp-body-open-marker");
       if (!marker) return;
 

--- a/EPFL-translate.php
+++ b/EPFL-translate.php
@@ -116,12 +116,9 @@ function display_banner () {
       const banner = document.createElement("div");
       banner.innerHTML = `
         <div class="container">
-          <div class="alert alert-info alert-dismissible fade show" role="alert" style="margin-bottom:0;">
+          <div class="alert alert-info fade show" role="alert" style="margin-bottom:0;">
             <strong><?php echo $translation; ?>
             </strong> <?php echo "$message"; ?>
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="this.parentElement.style.display='none';">
-              <span aria-hidden="true">&times;</span>
-            </button>
           </div>
         </div>
       `;

--- a/EPFL-translate.php
+++ b/EPFL-translate.php
@@ -11,7 +11,7 @@
  * Plugin Name: EPFL Translate
  * Plugin URI:  https://github.com/epfl-si/wp-plugin-epfl-translate
  * Description: Tweak the polylang language chooser widget to add a link to Google Translate
- * Version:     1.0.0
+ * Version:     1.1.0
  * Author:      ISAS-FSD
  * Author URI:  https://go.epfl.ch/idev-fsd
  * Contributor: Nicolas Borboën <nicolas.borboen@epfl.ch>, Saskya Panchaud <saskya.panchaud@epfl.ch>


### PR DESCRIPTION
When a page is translated, the nav-lang menu must be hidden and the alert box must no longer be closable. This way, clicking the link inside the alert box is the only way to return to the original page and choose another translation if needed.